### PR TITLE
Fix wording for problem BASICS: get

### DIFF
--- a/problems/basics_get/problem.txt
+++ b/problems/basics_get/problem.txt
@@ -2,7 +2,7 @@ Write a program that opens a LevelDB data-store using `{bold}level{/bold}`.
 
 The store will contain up to 10 entries with keys in the form:
 
-  gibberish{italic}X{/italic}
+  key{italic}X{/italic}
 
 Where '{italic}X{/italic}' is an integer between 0 and 100.
 
@@ -10,6 +10,7 @@ You must find those entries and print them out to the console, ordered
 by '{italic}X{/italic}', ascending. You should print them out with:
 
   console.log(key + '=' + value)
+  // will output "key12=here is that random text"
 
 The full path to the data-store will be provided to your program as
 the first command-line argument.

--- a/problems/basics_get/setup.js
+++ b/problems/basics_get/setup.js
@@ -11,7 +11,7 @@ function setup (run, callback) {
 
   while (i-- > 0) {
     k = Math.floor(Math.random() * (i == 1 ? 10 : 100))
-    ops.push({ type: 'put', key: 'gibberish' + k, value: gibberish() })
+    ops.push({ type: 'put', key: 'key' + k, value: gibberish() })
   }
 
   existing.writeAndClose(

--- a/problems/basics_get/solution.js
+++ b/problems/basics_get/solution.js
@@ -2,7 +2,7 @@ var level = require('level')
 var db = level(process.argv[2])
 
 function fetchNext (i) {
-  var key = 'gibberish' + i
+  var key = 'key' + i
   db.get(key, function (err, data) {
     if (err) {
       if (!err.notFound)


### PR DESCRIPTION
Fixed issue https://github.com/nodeschool/discussions/issues/96 copied below:

Hi,

In the "Basics: GET" test, the requirements say:

"""The store will contain up to 10 entries with keys in the form:

gibberishX

Where 'X' is an integer between 0 and 100."""

When reading this, I thought that gibberishX is something like ohdfuhaosX and not the actual word 'gibberish'. I suggest to change 'gibberish' to 'level' (or 'key') and explain that that's the actual key prefix.
