### PR TITLE
Unable to install levelmeup with node@4.2 LTS and npm@2.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "readable-stream": "~1.0.15",
     "through2-map": "~1.1.0",
     "through2": "~0.2.1",
-    "level-sublevel": "~6.2.1",
+    "level-sublevel": "~6.5.2",
     "multilevel": "~5.5.0"
   },
   "bin": "./levelmeup.js",


### PR DESCRIPTION
This PR just updates level-sublevel to 6.5.2 to avoid nodeschool/discussions#1154 (npm won't install levelmeup with node > 0.10).

I'm running a [NodeSchool on Saturday](/nodeschool/vancouver/issues/27) that's going to feature levelmeup, so if there's anything I can do to get this in let me know.
