### PR TITLE
Fix issue #62 npm ERR! fetch failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "readable-stream": "~1.0.15",
     "through2-map": "~1.1.0",
     "through2": "~0.2.1",
-    "level-sublevel": "~6.2.1",
+    "level-sublevel": "~6.5.4",
     "multilevel": "~5.5.0"
   },
   "bin": "./levelmeup.js",


### PR DESCRIPTION
Current version of `level-sublevel` (6.2.1) depends on a older version of `levelup` package which is from a non-exist source.(https://github.com/dominictarr/level-sublevel/blob/efc34b13b98d78e6ae936ba079f66d93127bde29/package.json#L13)
- Update the dependency, `level-sublevel` to latest version (6.5.4). 
