### PR TITLE
Check for unclosed lock in read-dbs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - '0.12'
+  - '4'
+  - '5'
+  - '6'
+  - '7'
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,11 @@ node_js:
   - '6'
   - '7'
 sudo: false
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **An intro to Node.js databases via a set of self-guided workshops.**
 
 [![NPM](https://nodei.co/npm/levelmeup.png?downloads=true&stars=true)](https://nodei.co/npm/levelmeup/) [![NPM](https://nodei.co/npm-dl/levelmeup.png?months=3)](https://nodei.co/npm/levelmeup/)
+[![Build Status](https://travis-ci.org/workshopper/levelmeup.svg?branch=master)](https://travis-ci.org/workshopper/levelmeup)
 
 ![Level Me Up Scotty!](https://github.com/rvagg/levelmeup/raw/master/levelmeup.png)
 

--- a/lib/formatDiff.js
+++ b/lib/formatDiff.js
@@ -7,7 +7,7 @@ function formatDeleted (diff) {
 }
 
 function formatEdited (diff) {
-  return '{diff.expected} `' + (diff.path.join('.') || 'result') + '` {diff.expected_tobe} \n\n```\n' + JSON.stringify(diff.lhs, null, 2) + '\n```\n{diff.expected_got}\n```\n' + JSON.stringify(diff.rhs, null, 2) +  '```\n\n'
+  return '{diff.expected} `' + (diff.path.join('.') || 'result') + '` {diff.expected_tobe} \n\n```\n' + JSON.stringify(diff.lhs, null, 2) + '\n```\n{diff.expected_got}\n```\n' + JSON.stringify(diff.rhs, null, 2) + '```\n\n'
 }
 
 function formatArray (diff) {
@@ -39,7 +39,5 @@ function formatChanges (changes) {
 }
 
 module.exports = function (diffs) {
-  return '\n\n'
-    + formatChanges(diffs)
-    + '\n'
+  return '\n\n' + formatChanges(diffs) + '\n'
 }

--- a/lib/read-db.js
+++ b/lib/read-db.js
@@ -1,19 +1,27 @@
 var level = require('level')
 
 module.exports = function (dir, valueEncoding, callback) {
-  var db = level(dir, { valueEncoding: valueEncoding })
-  var result = {}
-  var stream = db.readStream()
-  var error
-  stream.on('data', function (entry) {
-    result[entry.key] = entry.value
-  })
-  stream.on('error', function (err) {
-    error = err
-  })
-  stream.on('end', function () {
-    db.close(function (err) {
-      callback(error || err, result)
+  level(dir, { valueEncoding: valueEncoding }, function (err, db) {
+    if (err) {
+      if ( err.type === 'OpenError') {
+        return callback(dir + '\n\n{error.db.not_closed}')
+      } else {
+        return callback(dir + '\n\n{error.mod.unexpected}:\n\n```\n' + ((err && err.stack) || err) + '\n```')
+      }
+    }
+    var result = {}
+    var stream = db.readStream()
+    var error
+    stream.on('data', function (entry) {
+      result[entry.key] = entry.value
+    })
+    stream.on('error', function (err) {
+      error = err
+    })
+    stream.on('end', function () {
+      db.close(function (err) {
+        callback(error || err, result)
+      })
     })
   })
 }

--- a/lib/read-db.js
+++ b/lib/read-db.js
@@ -3,7 +3,7 @@ var level = require('level')
 module.exports = function (dir, valueEncoding, callback) {
   level(dir, { valueEncoding: valueEncoding }, function (err, db) {
     if (err) {
-      if ( err.type === 'OpenError') {
+      if (err.type === 'OpenError') {
         return callback(dir + '\n\n{error.db.not_closed}')
       } else {
         return callback(dir + '\n\n{error.mod.unexpected}:\n\n```\n' + ((err && err.stack) || err) + '\n```')

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "rimraf": "~2.5.4",
     "through2": "^2.0.1",
     "exec-module": "^2.0.0",
-    "workshopper-adventure": "^5.1.3"
+    "workshopper-adventure": "^5.1.8"
   },
   "devDependencies": {
     "standard": "^8.4.0",

--- a/test/sublevel/invalid_02.js
+++ b/test/sublevel/invalid_02.js
@@ -5,7 +5,7 @@ module.exports = function (databaseDir, callback) {
   var dinosaurs = db.sublevel('dinosaurs')
 
   ;[robots, dinosaurs].map(function (lev, i) {
-    lev.put('slogan', 1 === i ? 'rawr' : 'beep boop');
+    lev.put('slogan', i === 1 ? 'rawr' : 'beep boop')
   })
   setImmediate(callback)
 }

--- a/test/sublevel/invalid_02.js
+++ b/test/sublevel/invalid_02.js
@@ -1,0 +1,11 @@
+var level = require('level')
+module.exports = function (databaseDir, callback) {
+  var db = require('level-sublevel')(level(databaseDir))
+  var robots = db.sublevel('robots')
+  var dinosaurs = db.sublevel('dinosaurs')
+
+  ;[robots, dinosaurs].map(function (lev, i) {
+    lev.put('slogan', 1 === i ? 'rawr' : 'beep boop');
+  })
+  setImmediate(callback)
+}


### PR DESCRIPTION
If the solution doesn't close the database a unclear error is printed. This PR adds the same error display that is used in other parts of the workshopper also when reading the database for a comparsion.

This PR fixes #42. 