### PR TITLE
Add travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - '0.12'
+  - '4'
+  - '5'
+  - '6'
+  - '7'
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,11 @@ node_js:
   - '6'
   - '7'
 sudo: false
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **An intro to Node.js databases via a set of self-guided workshops.**
 
 [![NPM](https://nodei.co/npm/levelmeup.png?downloads=true&stars=true)](https://nodei.co/npm/levelmeup/) [![NPM](https://nodei.co/npm-dl/levelmeup.png?months=3)](https://nodei.co/npm/levelmeup/)
+[![Build Status](https://travis-ci.org/workshopper/levelmeup.svg?branch=master)](https://travis-ci.org/workshopper/levelmeup)
 
 ![Level Me Up Scotty!](https://github.com/rvagg/levelmeup/raw/master/levelmeup.png)
 

--- a/lib/formatDiff.js
+++ b/lib/formatDiff.js
@@ -7,7 +7,7 @@ function formatDeleted (diff) {
 }
 
 function formatEdited (diff) {
-  return '{diff.expected} `' + (diff.path.join('.') || 'result') + '` {diff.expected_tobe} \n\n```\n' + JSON.stringify(diff.lhs, null, 2) + '\n```\n{diff.expected_got}\n```\n' + JSON.stringify(diff.rhs, null, 2) +  '```\n\n'
+  return '{diff.expected} `' + (diff.path.join('.') || 'result') + '` {diff.expected_tobe} \n\n```\n' + JSON.stringify(diff.lhs, null, 2) + '\n```\n{diff.expected_got}\n```\n' + JSON.stringify(diff.rhs, null, 2) + '```\n\n'
 }
 
 function formatArray (diff) {
@@ -39,7 +39,5 @@ function formatChanges (changes) {
 }
 
 module.exports = function (diffs) {
-  return '\n\n'
-    + formatChanges(diffs)
-    + '\n'
+  return '\n\n' + formatChanges(diffs) + '\n'
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "rimraf": "~2.5.4",
     "through2": "^2.0.1",
     "exec-module": "^2.0.0",
-    "workshopper-adventure": "^5.1.3"
+    "workshopper-adventure": "^5.1.8"
   },
   "devDependencies": {
     "standard": "^8.4.0",


### PR DESCRIPTION
With 1.0.0 we now use workshopper-adventure and it also is standard linted. This PR adds travis tests to levelmeup that ensures that standard is maintained & runs some rudimentary tests against levelmeup.